### PR TITLE
Refactor createorupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,5 +341,5 @@ dep ensure
 Using the [operator-sdk](https://github.com/operator-framework/operator-sdk), run the operator locally:
 
 ```shell
-operator-sdk up local --namespace ""
+operator-sdk up local --namespace "namespace-configuration-operator"
 ```

--- a/README.md
+++ b/README.md
@@ -341,5 +341,5 @@ dep ensure
 Using the [operator-sdk](https://github.com/operator-framework/operator-sdk), run the operator locally:
 
 ```shell
-operator-sdk up local --namespace "namespace-configuration-operator"
+operator-sdk up local
 ```

--- a/pkg/controller/namespaceconfig/namespaceconfig_controller.go
+++ b/pkg/controller/namespaceconfig/namespaceconfig_controller.go
@@ -285,6 +285,12 @@ func createOrUpdate(client *dynamic.ResourceInterface, obj *unstructured.Unstruc
 	_, err := (*client).Create(obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
+			// We need to update
+			obj2, err := (*client).Get(obj.GetName(), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			obj.SetResourceVersion(obj2.GetResourceVersion())
 			_, err = (*client).Update(obj, metav1.UpdateOptions{})
 		}
 	}

--- a/pkg/controller/namespaceconfig/namespaceconfig_controller.go
+++ b/pkg/controller/namespaceconfig/namespaceconfig_controller.go
@@ -286,9 +286,6 @@ func createOrUpdate(client *dynamic.ResourceInterface, obj *unstructured.Unstruc
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			_, err = (*client).Update(obj, metav1.UpdateOptions{})
-			if err != nil {
-				return err
-			}
 		}
 	}
 	return err


### PR DESCRIPTION
There was a bug in the createOrUpdate method where the api would complain about the presence of a resource version when attempting to Update a previously created resource. 

Here's an example:

```
{"level":"error","ts":1568781734.1283247,"logger":"controller_namespaceconfig","msg":"unable to create object","object":{"apiVersion":"v1","kind":"ResourceQuota","metadata":{"labels":{"namespace-config-operator.redhat-cop.io_owner":"namespace-configuration-operator-large-size"},"name":"large-size","resourceVersion":"53652"},"spec":{"hard":{"requests.cpu":"8","requests.memory":"4Gi"}}},"error":"resourceVersion should not be set on objects to be created","stacktrace":"github.com/redhat-cop/namespace-configuration-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/redhat-cop/namespace-configuration-operator/pkg/controller/namespaceconfig.createOrUpdate\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/pkg/controller/namespaceconfig/namespaceconfig_controller.go:291\ngithub.com/redhat-cop/namespace-configuration-operator/pkg/controller/namespaceconfig.(*ReconcileNamespaceConfig).applyConfigToNamespace\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/pkg/controller/namespaceconfig/namespaceconfig_controller.go:276\ngithub.com/redhat-cop/namespace-configuration-operator/pkg/controller/namespaceconfig.(*ReconcileNamespaceConfig).Reconcile\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/pkg/controller/namespaceconfig/namespaceconfig_controller.go:216\ngithub.com/redhat-cop/namespace-configuration-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\ngithub.com/redhat-cop/namespace-configuration-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/redhat-cop/namespace-configuration-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/redhat-cop/namespace-configuration-operator/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/redhat-cop/namespace-configuration-operator/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/home/travis/gopath/src/github.com/redhat-cop/namespace-configuration-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

This PR fixes that bug, and heavily refactors the createOrUpdate method.