### PR TITLE
Modify namespace specific resource

### DIFF
--- a/pkg/controller/namespaceconfig/namespaceconfig_controller.go
+++ b/pkg/controller/namespaceconfig/namespaceconfig_controller.go
@@ -273,7 +273,8 @@ func (r *ReconcileNamespaceConfig) applyConfigToNamespace(objs []unstructured.Un
 		}
 		labels[operatorLabel] = label
 		obj.SetLabels(labels)
-		err = createOrUpdate(&namespacedObjIntf, &obj)
+		obj2 := obj.DeepCopy()
+		err = createOrUpdate(&namespacedObjIntf, obj2)
 		if err != nil {
 			return err
 		}
@@ -286,7 +287,8 @@ func createOrUpdate(client *dynamic.ResourceInterface, obj *unstructured.Unstruc
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			// We need to update
-			obj2, err := (*client).Get(obj.GetName(), metav1.GetOptions{})
+			var obj2 *unstructured.Unstructured
+			obj2, err = (*client).Get(obj.GetName(), metav1.GetOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Two errors occur during reconciliation after the initial resource creation has succeeded:
- the first namespace updated returns a "xxx already exists" error
- all other namespaces return a "resourceVersion should not be set on objects to be created" error

The first error is caused by the scope of the err variable. It is redefined, https://github.com/redhat-cop/namespace-configuration-operator/blob/master/pkg/controller/namespaceconfig/namespaceconfig_controller.go#L289. So the initial already exists error is never cleared and always returned at the end of the function.

The second error is caused by https://github.com/redhat-cop/namespace-configuration-operator/blob/master/pkg/controller/namespaceconfig/namespaceconfig_controller.go#L293. The first namespace encountered for an update sets the resource version of the config object. This config object (with the resource version of namespace 1) is then used for the next namespace in the create call.
The fix is the deep copy of the config object/resource before passing it to the createOrUpdate method, so this method can change whatever it want on the object/resource without affecting other namespaces.