### PR TITLE
missing image

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: namespace-configuration-operator
           # Replace this with the built image name
-          image: quay.io/redhat-cop/namespace-configuration-operator:0.0.3
+          image: quay.io/redhat-cop/namespace-configuration-operator:v0.1.0
           command:
           - namespace-configuration-operator
           imagePullPolicy: Always


### PR DESCRIPTION
There's no `0.0.3` tag listed for that image on quay. Eitther `v0.0.1`, `v0.0.2`, `v0.1.0` or `latest`.

`v0.1.0` seems to work.