### PR TITLE
Clarify matchLabel vs matchExpressions selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rm namespace-configuration-operator-${namespace-configuration-operator}.tgz
 
 ## Examples
 
-A `NamespaceConfig` CRD looks as follows:
+A `NamespaceConfig` CR looks as follows:
 
 ```yaml
 apiVersion: redhatcop.redhat.io/v1alpha1
@@ -63,6 +63,36 @@ In particular only the `"spec"` section of the json file will be reset. The foll
 * RoleBinding
 
 Any other objects that does not have the `spec` field is not supported and will result in an error. You are welcome to file requests for enhancement on non-standard resource types you'd like to be supported.
+
+### Selector: matchLabels vs matchExpressions
+
+The [selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) can be either a `matchLabel` or a `matchExpression`. For more information check the [k8s doc](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements) on this topic.
+
+A `NamespaceConfig` object using a `matchLabels` selector:
+
+```yaml
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: NamespaceConfig
+metadata:
+  name: special-sa
+spec:
+  selector:
+    matchLabels:
+      special-sa: "true"
+```
+
+A `NamespaceConfig` object using a `matchExpressions` selector:
+
+```yaml
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: NamespaceConfig
+metadata:
+  name: tier-config
+spec:
+  selector:
+    matchExpressions:
+      - {key: tier, operator: In, values: [gold,silver]}
+```
 
 ## Configuration Examples
 


### PR DESCRIPTION
Addressing https://github.com/redhat-cop/namespace-configuration-operator/issues/21 with a doc enhancement.