### PR TITLE
Move from Travis CI to Github Actions

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,0 +1,34 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ master, add-github-workflow ]
+  pull_request:
+    branches: [ master, add-github-workflow ]
+
+jobs:
+  test:
+    runs-on: [ubuntu-latest]
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Install docker
+      run: |
+        curl -fsSL https://get.docker.com -o get-docker.sh
+        sh get-docker.sh
+        #sudo apt-get -y update
+        #sudo apt-get -y upgrade
+        #sudo apt-get -y install docker.io
+
+    - uses: actions/checkout@v2
+
+    - name: Latest Deploy
+      run: make gh-actions-latest-deploy
+
+    - name: Release Deploy
+      run: make gh-actions-release-deploy

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,7 @@ REPOSITORY ?= $(REGISTRY)/redhat-cop/namespace-configuration-operator
 
 IMG := $(REPOSITORY):latest
 
-TRAVIS_TAG ?= latest
-
-VERSION := $(TRAVIS_TAG)
-
+VERSION := $(shell ./scripts/build/get-build-tag.sh)
 BUILD_COMMIT := $(shell ./scripts/build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./scripts/build/get-build-timestamp.sh)
 BUILD_HOSTNAME := $(shell ./scripts/build/get-build-hostname.sh)
@@ -99,6 +96,11 @@ publish-chart-repo:
 	./scripts/build/build-chart-repo.sh 
 	./scripts/build/push-to-pages.sh 
 
+
+#
+# NOTE:  When ready to remove Travis CI, delete these travis-*-deploy acions
+#
+
 # Travis Latest Tag Deployment
 travis-latest-deploy: docker-login docker-build docker-push-latest
 
@@ -107,3 +109,12 @@ travis-dev-deploy: docker-login docker-build docker-push-dev
 
 # Travis Release
 travis-release-deploy: docker-login docker-build docker-push-release publish-chart-repo
+
+# Github Actions Latest Tag Deployment
+gh-actions-latest-deploy: docker-login docker-build docker-push-latest
+
+# Github Actions Dev Deployment
+gh-actions-dev-deploy: docker-login docker-build docker-push-dev
+
+# Github Actions Release
+gh-actions-release-deploy: docker-login docker-build docker-push-release publish-chart-repo

--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ This is a cluster-level operator that you can deploy in any namespace, `namespac
 
 You can either deploy it using [`Helm`](https://helm.sh/) or creating the manifests directly.
 
-NOTE:
-**Given that a number of elevated permissions are required to create resources at a cluster scope, the account you are currently logged in must have elevated rights.**
+NOTE: *Elevated permissions are required to create resources at a cluster scope.  The account used to deploy the operator must have elevated rights.*
 
 ### Deploying with Helm
 

--- a/scripts/build/build-chart-repo.sh
+++ b/scripts/build/build-chart-repo.sh
@@ -1,7 +1,7 @@
 echo '>> Building charts...'
 find "$HELM_CHARTS_SOURCE" -mindepth 1 -maxdepth 1 -type d | while read chart; do
-  version=${TRAVIS_TAG} envsubst < $chart/values.yaml.tpl > $chart/values.yaml
-  version=${TRAVIS_TAG} envsubst < $chart/Chart.yaml.tpl  > $chart/Chart.yaml
+  version=${VERSION} envsubst < $chart/values.yaml.tpl > $chart/values.yaml
+  version=${VERSION} envsubst < $chart/Chart.yaml.tpl  > $chart/Chart.yaml
   echo ">>> helm lint $chart"
   helm lint "$chart"
   chart_dest=$HELM_CHART_DEST/"`basename "$chart"`"

--- a/scripts/build/get-build-tag.sh
+++ b/scripts/build/get-build-tag.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+GIT_TAG=$(git describe --exact-match --tags HEAD)
+
+if [ -n "$GIT_TAG" ]; then
+    echo "$GIT_TAG"
+else
+    echo "latest"
+fi


### PR DESCRIPTION
This is as far as I could get without having credentials to the Docker
registry.  This build fails at `docker login` since it doesn't have
those creds loaded into environment variables in github.

The Travis CI should continue to work until the `.travis.yml` file is
removed.  The `Makefile` recipes are still there as well and can be
deleted once we're ready to decommission the Travis build.

To finish migrating to GH Actions you'll need to populate the
environment variables in Github with the username/password and registry.