### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ oc new-project namespace-configuration-operator
 
 helm repo add namespace-configuration-operator https://redhat-cop.github.io/namespace-configuration-operator
 helm repo update
-export namespace_configuration_operator_chart_version=$(helm search namespace-configuration-operator/namespace-configuration-operator | grep namespace-configuration-operator/namespace-configuration-operator | awk '{print $2}')
+export namespace_configuration_operator_chart_version=$(helm search repo --max-col-width=65 namespace-configuration-operator/namespace-configuration-operator | grep namespace-configuration-operator/namespace-configuration-operator | awk '{print $2}')
 
 helm fetch namespace-configuration-operator/namespace-configuration-operator --version ${namespace_configuration_operator_chart_version}
 helm template namespace-configuration-operator-${namespace_configuration_operator_chart_version}.tgz --namespace namespace-configuration-operator | oc apply -f - -n namespace-configuration-operator

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ oc new-project namespace-configuration-operator
 
 helm repo add namespace-configuration-operator https://redhat-cop.github.io/namespace-configuration-operator
 helm repo update
-export namespace_configuration_operator_chart_version=$(helm search repo --max-col-width=65 namespace-configuration-operator/namespace-configuration-operator | grep namespace-configuration-operator/namespace-configuration-operator | awk '{print $2}')
-
-helm fetch namespace-configuration-operator/namespace-configuration-operator --version ${namespace_configuration_operator_chart_version}
-helm template namespace-configuration-operator-${namespace_configuration_operator_chart_version}.tgz --namespace namespace-configuration-operator | oc apply -f - -n namespace-configuration-operator
-
-rm namespace-configuration-operator-${namespace_configuration_operator_chart_version}.tgz
+helm install namespace-configuration-operator namespace-configuration-operator/namespace-configuration-operator
+```
+This can later be updated with the following commands:
+```shell
+helm repo update
+helm upgrade namespace-configuration-operator namespace-configuration-operator/namespace-configuration-operator
 ```
 
 ### Deploying directly with manifests


### PR DESCRIPTION
Update helm release instructions.  As originally written, the command to set the version fails:
 * `helm search` requires `repo` 
 * the `grep` won't find the search parameter due to column width limitations