### PR TITLE
Corrected missing `spec:` in NamespaceConfig example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: NamespaceConfig
 metadata:
   name: small-namespace
+spec:
   labelSelector:
     matchLabels:
       size: small  


### PR DESCRIPTION
The example NamespaceConfig in the README.md file is missing `spec:` in the yaml.

```yaml
apiVersion: redhatcop.redhat.io/v1alpha1
kind: NamespaceConfig
metadata:
  name: small-namespace
  labelSelector:
    matchLabels:
      size: small  
  templates:
  - objectTemplate: |
      apiVersion: v1
      kind: ResourceQuota
      metadata:
        name: small-size
        namespace: {{ .Name }}
      spec:
        hard:
          requests.cpu: "4"
          requests.memory: "2Gi"
```