### PR TITLE
Bumped UBI version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/namespace-configuration-operator \
     USER_UID=1001 \


### PR DESCRIPTION
Please bump the version of the UBI image you are using.
Quay.io/Clair is currently complaining a lot about High Security Risks: https://quay.io/repository/redhat-cop/namespace-configuration-operator/manifest/sha256:14f2a43821fbef657386dd2546dc5b6bf1c5372a1f25e3a2e0f6caf867dd7d93?tab=vulnerabilities