### PR TITLE
Add support for adding environment variable in the helm chart

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -30,6 +30,10 @@ spec:
         - --leader-elect
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.env }}
+        env:
+         {{- toYaml . | nindent 8 }}
+        {{- end }}
         name: {{ .Chart.Name }} 
         resources:
           {{- toYaml .Values.resources | nindent 12 }}

--- a/config/helmchart/values.yaml.tpl
+++ b/config/helmchart/values.yaml.tpl
@@ -13,7 +13,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-
+env: []
 podAnnotations: {}
 
 resources:


### PR DESCRIPTION
This PR adds support for adding environment variables in the helm chart. As #93 allows reconciliation against system-associated namespaces in namespaceconfig controller by using environment variable, we should be able to configure that with helm chart.