### PR TITLE
Enable Configuration of Logging Format in Helm Chart Deployment

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -48,6 +48,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --zap-devel={{ .Values.logging.Development }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:

--- a/config/helmchart/values.yaml.tpl
+++ b/config/helmchart/values.yaml.tpl
@@ -38,3 +38,6 @@ kube_rbac_proxy:
       memory: 20Mi
 
 enableMonitoring: true
+
+logging:
+  Development: false


### PR DESCRIPTION
This PR introduces an update to the Helm chart, enabling the selection of the logging format as either "development" or "production." 

More info about log options,
https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.BindFlags 

```
opts := zap.Options{Development: true,}
opts.BindFlags(flag.CommandLine)
flag.Parse()
```

By default, the helm chart deployment will use the development mode settings because the above code block, allowing logs to be in plain format. 

However, with my changes to the helm chart, the user has the ability to tailor the log output to match their specific needs. Whether they prefer a JSON format for easier log parsing and analysis or a plain format for more straightforward readability, the helm chart now accommodates both options.