### PR TITLE
Namespace field missing for Deploy manifest

### DIFF
--- a/config/helmchart/templates/manager.yaml
+++ b/config/helmchart/templates/manager.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "namespace-configuration-operator.fullname" . }}
   labels:
     {{- include "namespace-configuration-operator.labels" . | nindent 4 }}
+  namespace:  {{ include "namespace-configuration-operator.fullname" . }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This PR will add a namespace field for deployment manifest .

Got an issue when deploying the helm charts via Argocd. 

`Namespace for namespace-configuration-operator apps/v1, Kind=Deployment is missing.`